### PR TITLE
agent新增日志,配置项以及优化采集,Server启动失败重启容器,IP 归属地/会话回填死锁优化,新增agent的Dockerfile

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.7
+
+FROM golang:1.24.0-alpine AS builder
+
+WORKDIR /src
+RUN apk add --no-cache ca-certificates git
+
+COPY go.mod go.sum ./
+
+# 可选：构建时允许通过参数覆盖 GOPROXY（适用于企业内网代理/镜像源）。
+ARG GOPROXY
+RUN if [ -n "${GOPROXY:-}" ]; then go env -w GOPROXY="${GOPROXY}"; fi && go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 \
+    GOOS=${TARGETOS:-$(go env GOOS)} \
+    GOARCH=${TARGETARCH:-$(go env GOARCH)} \
+    go build -trimpath -ldflags="-s -w" -o /out/nginxpulse-agent ./cmd/nginxpulse-agent
+
+FROM alpine:3.20 AS runtime
+
+WORKDIR /app
+RUN apk add --no-cache ca-certificates tzdata \
+    && adduser -S -D -H -u 10001 nginxpulse-agent
+
+COPY --from=builder /out/nginxpulse-agent /app/nginxpulse-agent
+RUN chmod +x /app/nginxpulse-agent
+
+USER 10001
+ENTRYPOINT ["/app/nginxpulse-agent"]
+CMD ["-config", "/etc/nginxpulse/agent.json"]
+

--- a/cmd/nginxpulse/main.go
+++ b/cmd/nginxpulse/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"os"
+	"strings"
+	"syscall"
 
 	"github.com/likaia/nginxpulse/internal/app"
 	"github.com/sirupsen/logrus"
@@ -10,6 +12,27 @@ import (
 func main() {
 	if err := app.Run(); err != nil {
 		logrus.WithError(err).Error("服务启动失败")
+		// 在容器的 "direct" 启动模式中，nginx 往往是 PID 1，而 Go 后端是后台启动的子进程。
+		// 此时即使后端启动失败退出，容器仍可能因为 nginx 仍在前台而保持 Running。
+		// 为了让“启动失败=容器退出”成立，这里检测到 PID 1 为 nginx 时会向其发送 SIGTERM。
+		// 安全性：仅在确认 PID 1 是 nginx 时才执行，避免误伤其它运行环境。
+		tryTerminatePID1IfNginx()
 		os.Exit(1)
 	}
+}
+
+func tryTerminatePID1IfNginx() {
+	commBytes, err := os.ReadFile("/proc/1/comm")
+	if err != nil {
+		return
+	}
+	comm := strings.TrimSpace(string(commBytes))
+	if comm != "nginx" {
+		return
+	}
+	if err := syscall.Kill(1, syscall.SIGTERM); err != nil {
+		logrus.WithError(err).Warn("服务启动失败：尝试终止 PID 1 (nginx) 失败")
+		return
+	}
+	logrus.Warn("服务启动失败：检测到 PID 1 为 nginx，已发送 SIGTERM 以终止容器")
 }

--- a/configs/nginxpulse_agent.example.json
+++ b/configs/nginxpulse_agent.example.json
@@ -1,0 +1,47 @@
+{
+  // nginxpulse-server 的访问地址（注意包含端口 8089）
+  // 例如集群内： http://nginxpulse-server.monitoring.svc:8089
+  "server": "http://nginxpulse-server.monitoring.svc:8089",
+
+  // 可选：如果 server 侧启用了 access key，则填这里
+  "accessKey": "",
+
+  // 必填：站点 ID（对应 nginxpulse 的网站配置/后台生成的 ID）
+  "websiteID": "1207",
+
+  // 可选：来源 ID（建议填，便于区分不同 agent）
+  "sourceID": "agent-ingress",
+
+  // 必填：要采集的日志文件路径列表（容器内路径）
+  // 说明：当前 agent 会跳过 .gz 文件
+  "paths": [
+    "/data/nginxpulse/ingress-json.log"
+  ],
+
+  // 轮询间隔：多久读一次“新增内容”
+  "pollInterval": "20s",
+
+  // 批大小：pending 累积到多少行就尝试推送一次
+  "batchSize": 1000,
+
+  // 刷新间隔：即便没到 batchSize，也会按这个间隔尝试推送 pending
+  "flushInterval": "40s",
+
+  // 推送请求超时
+  "requestTimeout": "50m",
+
+  // pending 最大积压行数：到达后暂停继续读取（背压）
+  "maxPendingLines": 1000,
+
+  // 单行最大长度（字节）：超过会丢弃并打印 warning（防止超长行导致 OOM）
+  // 默认 256KiB；建议 ingress-json 这种场景可以先 256KiB 或 1MiB
+  "maxLineBytes": 262144,
+
+  // 失败重试退避（指数退避）
+  "retryBackoffMin": "1s",
+  "retryBackoffMax": "30s",
+
+  // 可选：达到最大退避后仍失败则退出进程（用于让 k8s 重启容器）
+  // 默认 false，建议先 false，确认网络/服务端稳定后再考虑打开
+  "exitOnMaxBackoff": false
+}

--- a/internal/enrich/ip_geo.go
+++ b/internal/enrich/ip_geo.go
@@ -753,7 +753,7 @@ func isISPLabel(value string) bool {
 		}
 	}
 	ispKeywords := []string{
-		"电信", "联通", "移动", "铁通", "广电", "网通", "教育网", "长城宽带", "有线", "鹏博士", "阿里",
+		"电信", "联通", "移动", "铁通", "广电", "网通", "教育网", "长城宽带", "有线", "鹏博士",
 	}
 	for _, keyword := range ispKeywords {
 		if strings.Contains(clean, keyword) {


### PR DESCRIPTION
各部分改动内容概述（按模块）
1) Agent（cmd/nginxpulse-agent/main.go）
新增配置项与行为：
requestTimeout：推送 HTTP 超时
maxPendingLines：pending 积压上限（达到后背压暂停读取）
maxLineBytes：单行最大字节数，超长行跳过并告警（防 OOM）
retryBackoffMin/max：指数退避
exitOnMaxBackoff：达到最大退避后仍失败则退出进程（便于 k8s 重启）
新增诊断日志：
启动配置摘要、读文件统计（行数/字节/offset）、推送失败/退避、周期性内存统计（heap_alloc/heap_sys 等）
内存/heap_sys 优化：
推送成功后 不再复用 pending 的 backing array，而是直接换新 slice（降低旧字符串引用残留导致的 heap_sys 持续走高风险）
健壮性：
applyEnvOverrides 支持更多环境变量覆盖（例如 NGINXPULSE_AGENT_MAX_LINE_BYTES、NGINXPULSE_AGENT_EXIT_ON_MAX_BACKOFF）
2) Server 启动失败时退出容器（cmd/nginxpulse/main.go）
在 app.Run() 失败时，除了 os.Exit(1)，还会在 PID 1 为 nginx 的情况下向其发送 SIGTERM，避免 direct 模式下“后端失败但 nginx 仍在前台导致容器不退出”的情况。
3) IP 归属地/会话回填死锁优化（internal/enrich/ip_geo.go、internal/store/repository.go）
从 git diff 片段能看到主要集中在 repository 的会话/聚合写入路径：
新增 pg advisory lock（按 (ip_id, ua_id)、按天聚合 key）以减少并发写同一会话/同一天聚合导致的死锁/锁等待
把循环内频繁 UPDATE/UPSERT 改为“内存累加 + 事务末尾收敛落库”：
会话表 page_count 从 +1 改为 +?（增量累加）
daily/session-entry 聚合从固定 +1 改为按增量 excluded.count/sessions
聚合落库前对 day、entry_id 排序，降低锁顺序随机性
新增/调整 SQL statement 与结构：
新增 lockSessionKey / lockAggSessionDaily
引入 pendingSessionUpdate / pendingSessionStateUpsert 等收敛结构
4) Docker/配置示例
新增 Dockerfile.agent：改为多阶段构建（镜像内编译 agent，runtime 用 alpine，镜像体积显著变小）。
新增 agent 配置示例：configs/nginxpulse_agent.example.json（带注释示例文件）。
5)修改归属地含"阿里"引发的Bug