### PR TITLE
agent新增日志,配置项以及优化采集,Server启动失败重启容器,IP 归属地/会话回填死锁优化,新增agent的Dockerfile

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.7
+
+FROM golang:1.24.0-alpine AS builder
+
+WORKDIR /src
+RUN apk add --no-cache ca-certificates git
+
+COPY go.mod go.sum ./
+
+# 可选：构建时允许通过参数覆盖 GOPROXY（适用于企业内网代理/镜像源）。
+ARG GOPROXY
+RUN if [ -n "${GOPROXY:-}" ]; then go env -w GOPROXY="${GOPROXY}"; fi && go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 \
+    GOOS=${TARGETOS:-$(go env GOOS)} \
+    GOARCH=${TARGETARCH:-$(go env GOARCH)} \
+    go build -trimpath -ldflags="-s -w" -o /out/nginxpulse-agent ./cmd/nginxpulse-agent
+
+FROM alpine:3.20 AS runtime
+
+WORKDIR /app
+RUN apk add --no-cache ca-certificates tzdata \
+    && adduser -S -D -H -u 10001 nginxpulse-agent
+
+COPY --from=builder /out/nginxpulse-agent /app/nginxpulse-agent
+RUN chmod +x /app/nginxpulse-agent
+
+USER 10001
+ENTRYPOINT ["/app/nginxpulse-agent"]
+CMD ["-config", "/etc/nginxpulse/agent.json"]
+

--- a/cmd/nginxpulse/main.go
+++ b/cmd/nginxpulse/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"os"
+	"strings"
+	"syscall"
 
 	"github.com/likaia/nginxpulse/internal/app"
 	"github.com/sirupsen/logrus"
@@ -10,6 +12,27 @@ import (
 func main() {
 	if err := app.Run(); err != nil {
 		logrus.WithError(err).Error("服务启动失败")
+		// 在容器的 "direct" 启动模式中，nginx 往往是 PID 1，而 Go 后端是后台启动的子进程。
+		// 此时即使后端启动失败退出，容器仍可能因为 nginx 仍在前台而保持 Running。
+		// 为了让“启动失败=容器退出”成立，这里检测到 PID 1 为 nginx 时会向其发送 SIGTERM。
+		// 安全性：仅在确认 PID 1 是 nginx 时才执行，避免误伤其它运行环境。
+		tryTerminatePID1IfNginx()
 		os.Exit(1)
 	}
+}
+
+func tryTerminatePID1IfNginx() {
+	commBytes, err := os.ReadFile("/proc/1/comm")
+	if err != nil {
+		return
+	}
+	comm := strings.TrimSpace(string(commBytes))
+	if comm != "nginx" {
+		return
+	}
+	if err := syscall.Kill(1, syscall.SIGTERM); err != nil {
+		logrus.WithError(err).Warn("服务启动失败：尝试终止 PID 1 (nginx) 失败")
+		return
+	}
+	logrus.Warn("服务启动失败：检测到 PID 1 为 nginx，已发送 SIGTERM 以终止容器")
 }

--- a/configs/nginxpulse_agent.example.json
+++ b/configs/nginxpulse_agent.example.json
@@ -1,0 +1,47 @@
+{
+  // nginxpulse-server 的访问地址（注意包含端口 8089）
+  // 例如集群内： http://nginxpulse-server.monitoring.svc:8089
+  "server": "http://nginxpulse-server.monitoring.svc:8089",
+
+  // 可选：如果 server 侧启用了 access key，则填这里
+  "accessKey": "",
+
+  // 必填：站点 ID（对应 nginxpulse 的网站配置/后台生成的 ID）
+  "websiteID": "1207",
+
+  // 可选：来源 ID（建议填，便于区分不同 agent）
+  "sourceID": "agent-ingress",
+
+  // 必填：要采集的日志文件路径列表（容器内路径）
+  // 说明：当前 agent 会跳过 .gz 文件
+  "paths": [
+    "/data/nginxpulse/ingress-json.log"
+  ],
+
+  // 轮询间隔：多久读一次“新增内容”
+  "pollInterval": "20s",
+
+  // 批大小：pending 累积到多少行就尝试推送一次
+  "batchSize": 1000,
+
+  // 刷新间隔：即便没到 batchSize，也会按这个间隔尝试推送 pending
+  "flushInterval": "40s",
+
+  // 推送请求超时
+  "requestTimeout": "50m",
+
+  // pending 最大积压行数：到达后暂停继续读取（背压）
+  "maxPendingLines": 1000,
+
+  // 单行最大长度（字节）：超过会丢弃并打印 warning（防止超长行导致 OOM）
+  // 默认 256KiB；建议 ingress-json 这种场景可以先 256KiB 或 1MiB
+  "maxLineBytes": 262144,
+
+  // 失败重试退避（指数退避）
+  "retryBackoffMin": "1s",
+  "retryBackoffMax": "30s",
+
+  // 可选：达到最大退避后仍失败则退出进程（用于让 k8s 重启容器）
+  // 默认 false，建议先 false，确认网络/服务端稳定后再考虑打开
+  "exitOnMaxBackoff": false
+}

--- a/internal/enrich/ip_geo.go
+++ b/internal/enrich/ip_geo.go
@@ -822,7 +822,7 @@ func isISPLabel(value string) bool {
 		}
 	}
 	ispKeywords := []string{
-		"电信", "联通", "移动", "铁通", "广电", "网通", "教育网", "长城宽带", "有线", "鹏博士", "阿里",
+		"电信", "联通", "移动", "铁通", "广电", "网通", "教育网", "长城宽带", "有线", "鹏博士",
 	}
 	for _, keyword := range ispKeywords {
 		if strings.Contains(clean, keyword) {

--- a/internal/store/repository.go
+++ b/internal/store/repository.go
@@ -1050,7 +1050,7 @@ func (r *Repository) detectIPGeoAnomaliesForWebsite(websiteID string, limit int)
 }
 
 var ipGeoAnomalyKeywords = []string{
-	"电信", "联通", "移动", "铁通", "广电", "网通", "教育网", "长城宽带", "有线", "鹏博士", "阿里",
+	"电信", "联通", "移动", "铁通", "广电", "网通", "教育网", "长城宽带", "有线", "鹏博士",
 }
 
 func buildIPGeoAnomalyWhereClause(domesticColumn, globalColumn string, args *[]interface{}) string {
@@ -1279,6 +1279,14 @@ func (r *Repository) batchInsertLogsForWebsiteOnce(websiteID string, logs []Ngin
 		return err
 	}
 	defer firstSeenStmt.Close()
+	lockFirstSeenStmt, err := tx.Prepare(sqlutil.ReplacePlaceholders(fmt.Sprintf(
+		`SELECT pg_advisory_xact_lock(hashtext('%s:first_seen'), hashint8(?))`,
+		websiteID,
+	)))
+	if err != nil {
+		return err
+	}
+	defer lockFirstSeenStmt.Close()
 	sessions, err := prepareSessionStatements(tx, websiteID)
 	if err != nil {
 		return err
@@ -1299,6 +1307,13 @@ func (r *Repository) batchInsertLogsForWebsiteOnce(websiteID string, logs []Ngin
 	cache := newDimCaches()
 	aggBatch := newAggBatch()
 	sessionCache := make(map[string]sessionState)
+	// 会话聚合：在事务内先累加，提交前收敛落库，避免每条新会话都去争抢同一天聚合行。
+	sessionAggDaily := make(map[string]int64)
+	sessionAggEntry := make(map[string]map[int64]int64)
+	// 会话更新/状态：在事务内先累加，提交前按稳定顺序落库，避免在维表写入/锁等待期间提前持有 sessions 行锁。
+	sessionUpdates := make(map[int64]*pendingSessionUpdate)
+	sessionStateUpserts := make(map[string]pendingSessionStateUpsert)
+	lockedSessionKeys := make(map[string]struct{})
 	// 将 first_seen 的写入从“每条日志一次 upsert”改为“本批次去重后按 ip_id 顺序写入”，降低死锁概率与锁竞争。
 	firstSeenMinTs := make(map[int64]int64)
 
@@ -1361,6 +1376,11 @@ func (r *Repository) batchInsertLogsForWebsiteOnce(websiteID string, logs []Ngin
 			if err := updateSessionFromLog(
 				sessions,
 				sessionCache,
+				sessionAggDaily,
+				sessionAggEntry,
+				sessionUpdates,
+				sessionStateUpserts,
+				lockedSessionKeys,
 				ipID,
 				uaID,
 				locationID,
@@ -1382,6 +1402,9 @@ func (r *Repository) batchInsertLogsForWebsiteOnce(websiteID string, logs []Ngin
 		}
 		sort.Slice(ipIDs, func(i, j int) bool { return ipIDs[i] < ipIDs[j] })
 		for _, ipID := range ipIDs {
+			if _, err := lockFirstSeenStmt.Exec(ipID); err != nil {
+				return err
+			}
 			if _, err := firstSeenStmt.Exec(ipID, firstSeenMinTs[ipID]); err != nil {
 				return err
 			}
@@ -1389,6 +1412,19 @@ func (r *Repository) batchInsertLogsForWebsiteOnce(websiteID string, logs []Ngin
 	}
 
 	if err := applyAggUpdates(aggs, aggBatch); err != nil {
+		return err
+	}
+
+	// 在提交前的收敛阶段一次性写入会话聚合，并在每个 day 上使用 advisory lock 将并发写串行化（避免死锁）。
+	if err := applySessionAggUpdatesWithLocks(sessions, sessionAggDaily, sessionAggEntry); err != nil {
+		return err
+	}
+
+	// 会话 UPDATE / session_state upsert：收敛到事务末尾一次性落库，尽量缩短 sessions 行锁持有时间。
+	if err := applySessionUpdates(sessions, sessionUpdates); err != nil {
+		return err
+	}
+	if err := applySessionStateUpserts(sessions, sessionStateUpserts); err != nil {
 		return err
 	}
 
@@ -1957,6 +1993,8 @@ type sessionStatements struct {
 	upsertState      *sql.Stmt
 	insertSession    *sql.Stmt
 	updateSession    *sql.Stmt
+	lockSessionKey      *sql.Stmt
+	lockAggSessionDaily *sql.Stmt
 	upsertDaily      *sql.Stmt
 	upsertEntryDaily *sql.Stmt
 }
@@ -1979,6 +2017,19 @@ type aggBatch struct {
 }
 
 type sessionState struct {
+	sessionID int64
+	lastTs    int64
+}
+
+type pendingSessionUpdate struct {
+	endTs          int64
+	exitURLID      int64
+	pageCountDelta int64
+}
+
+type pendingSessionStateUpsert struct {
+	ipID      int64
+	uaID      int64
 	sessionID int64
 	lastTs    int64
 }
@@ -2044,6 +2095,8 @@ func (s *sessionStatements) Close() {
 	closeStmt(s.upsertState)
 	closeStmt(s.insertSession)
 	closeStmt(s.updateSession)
+	closeStmt(s.lockSessionKey)
+	closeStmt(s.lockAggSessionDaily)
 	closeStmt(s.upsertDaily)
 	closeStmt(s.upsertEntryDaily)
 }
@@ -2295,7 +2348,7 @@ func prepareSessionStatements(tx *sql.Tx, websiteID string) (*sessionStatements,
 	}
 
 	updateSession, err := tx.Prepare(sqlutil.ReplacePlaceholders(fmt.Sprintf(
-		`UPDATE "%s" SET end_ts = ?, exit_url_id = ?, page_count = page_count + 1 WHERE id = ?`, sessionTable,
+		`UPDATE "%s" SET end_ts = ?, exit_url_id = ?, page_count = page_count + ? WHERE id = ?`, sessionTable,
 	)))
 	if err != nil {
 		insertSession.Close()
@@ -2304,11 +2357,9 @@ func prepareSessionStatements(tx *sql.Tx, websiteID string) (*sessionStatements,
 		return nil, err
 	}
 
-	upsertDaily, err := tx.Prepare(sqlutil.ReplacePlaceholders(fmt.Sprintf(
-		`INSERT INTO "%s" (day, sessions)
-         VALUES (?, 1)
-         ON CONFLICT (day) DO UPDATE SET
-             sessions = "%s".sessions + 1`, dailyTable, dailyTable,
+	lockSessionKey, err := tx.Prepare(sqlutil.ReplacePlaceholders(fmt.Sprintf(
+		`SELECT pg_advisory_xact_lock(hashtext('%s:session'), (hashint8(?) # hashint8(?)))`,
+		websiteID,
 	)))
 	if err != nil {
 		updateSession.Close()
@@ -2318,14 +2369,45 @@ func prepareSessionStatements(tx *sql.Tx, websiteID string) (*sessionStatements,
 		return nil, err
 	}
 
+	lockAggSessionDaily, err := tx.Prepare(sqlutil.ReplacePlaceholders(fmt.Sprintf(
+		`SELECT pg_advisory_xact_lock(hashtext('%s:agg_session_daily'), hashtext(?))`,
+		websiteID,
+	)))
+	if err != nil {
+		lockSessionKey.Close()
+		updateSession.Close()
+		insertSession.Close()
+		upsertState.Close()
+		selectState.Close()
+		return nil, err
+	}
+
+	upsertDaily, err := tx.Prepare(sqlutil.ReplacePlaceholders(fmt.Sprintf(
+		`INSERT INTO "%s" (day, sessions)
+         VALUES (?, ?)
+         ON CONFLICT (day) DO UPDATE SET
+             sessions = "%s".sessions + excluded.sessions`, dailyTable, dailyTable,
+	)))
+	if err != nil {
+		lockAggSessionDaily.Close()
+		lockSessionKey.Close()
+		updateSession.Close()
+		insertSession.Close()
+		upsertState.Close()
+		selectState.Close()
+		return nil, err
+	}
+
 	upsertEntryDaily, err := tx.Prepare(sqlutil.ReplacePlaceholders(fmt.Sprintf(
 		`INSERT INTO "%s" (day, entry_url_id, count)
-         VALUES (?, ?, 1)
+         VALUES (?, ?, ?)
          ON CONFLICT (day, entry_url_id) DO UPDATE SET
-             count = "%s".count + 1`, entryTable, entryTable,
+             count = "%s".count + excluded.count`, entryTable, entryTable,
 	)))
 	if err != nil {
 		upsertDaily.Close()
+		lockAggSessionDaily.Close()
+		lockSessionKey.Close()
 		updateSession.Close()
 		insertSession.Close()
 		upsertState.Close()
@@ -2338,9 +2420,124 @@ func prepareSessionStatements(tx *sql.Tx, websiteID string) (*sessionStatements,
 		upsertState:      upsertState,
 		insertSession:    insertSession,
 		updateSession:    updateSession,
+		lockSessionKey:      lockSessionKey,
+		lockAggSessionDaily: lockAggSessionDaily,
 		upsertDaily:      upsertDaily,
 		upsertEntryDaily: upsertEntryDaily,
 	}, nil
+}
+
+func applySessionAggUpdatesWithLocks(
+	stmts *sessionStatements,
+	sessionAggDaily map[string]int64,
+	sessionAggEntry map[string]map[int64]int64,
+) error {
+	if stmts == nil {
+		return nil
+	}
+	if len(sessionAggDaily) == 0 && len(sessionAggEntry) == 0 {
+		return nil
+	}
+
+	daySet := make(map[string]struct{}, len(sessionAggDaily)+len(sessionAggEntry))
+	for day := range sessionAggDaily {
+		daySet[day] = struct{}{}
+	}
+	for day := range sessionAggEntry {
+		daySet[day] = struct{}{}
+	}
+	days := make([]string, 0, len(daySet))
+	for day := range daySet {
+		days = append(days, day)
+	}
+	sort.Strings(days)
+
+	for _, day := range days {
+		// 关键：按天加 advisory lock，确保不同事务对同一天聚合行的写入串行化，避免死锁。
+		// 这里是“收敛阶段”才加锁，锁持有时间最短（只覆盖聚合落库这几条语句）。
+		if stmts.lockAggSessionDaily != nil {
+			if _, err := stmts.lockAggSessionDaily.Exec(day); err != nil {
+				return err
+			}
+		}
+
+		if stmts.upsertDaily != nil {
+			if delta := sessionAggDaily[day]; delta > 0 {
+				if _, err := stmts.upsertDaily.Exec(day, delta); err != nil {
+					return err
+				}
+			}
+		}
+
+		if stmts.upsertEntryDaily != nil {
+			entryDelta := sessionAggEntry[day]
+			if len(entryDelta) > 0 {
+				entryIDs := make([]int64, 0, len(entryDelta))
+				for entryID := range entryDelta {
+					entryIDs = append(entryIDs, entryID)
+				}
+				sort.Slice(entryIDs, func(i, j int) bool { return entryIDs[i] < entryIDs[j] })
+				for _, entryID := range entryIDs {
+					delta := entryDelta[entryID]
+					if delta <= 0 {
+						continue
+					}
+					if _, err := stmts.upsertEntryDaily.Exec(day, entryID, delta); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func applySessionUpdates(
+	stmts *sessionStatements,
+	updates map[int64]*pendingSessionUpdate,
+) error {
+	if stmts == nil || stmts.updateSession == nil || len(updates) == 0 {
+		return nil
+	}
+	ids := make([]int64, 0, len(updates))
+	for id := range updates {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		upd := updates[id]
+		if upd == nil || upd.pageCountDelta <= 0 {
+			continue
+		}
+		if _, err := stmts.updateSession.Exec(upd.endTs, upd.exitURLID, upd.pageCountDelta, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applySessionStateUpserts(
+	stmts *sessionStatements,
+	upserts map[string]pendingSessionStateUpsert,
+) error {
+	if stmts == nil || stmts.upsertState == nil || len(upserts) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(upserts))
+	for k := range upserts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		u := upserts[k]
+		if u.ipID == 0 || u.uaID == 0 || u.sessionID == 0 || u.lastTs == 0 {
+			continue
+		}
+		if _, err := stmts.upsertState.Exec(u.ipID, u.uaID, u.sessionID, u.lastTs); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func applyAggUpdates(aggs *aggStatements, batch *aggBatch) error {
@@ -2650,6 +2847,11 @@ func addCounts(counts *aggCounts, log NginxLogRecord) {
 func updateSessionFromLog(
 	stmts *sessionStatements,
 	cache map[string]sessionState,
+	sessionAggDaily map[string]int64,
+	sessionAggEntry map[string]map[int64]int64,
+	sessionUpdates map[int64]*pendingSessionUpdate,
+	sessionStateUpserts map[string]pendingSessionStateUpsert,
+	lockedSessionKeys map[string]struct{},
 	ipID,
 	uaID,
 	locationID,
@@ -2660,6 +2862,17 @@ func updateSessionFromLog(
 		return nil
 	}
 	key := fmt.Sprintf("%d|%d", ipID, uaID)
+
+	// 关键：按 (ip_id, ua_id) 串行化会话写入，避免多个并发事务同时更新同一会话链路导致 tuple/transactionid 锁等待甚至死锁。
+	if stmts.lockSessionKey != nil && lockedSessionKeys != nil {
+		if _, ok := lockedSessionKeys[key]; !ok {
+			if _, err := stmts.lockSessionKey.Exec(ipID, uaID); err != nil {
+				return err
+			}
+			lockedSessionKeys[key] = struct{}{}
+		}
+	}
+
 	state, ok := cache[key]
 	if !ok {
 		var sessionID int64
@@ -2688,26 +2901,42 @@ func updateSessionFromLog(
 			return err
 		}
 		day := dayBucket(time.Unix(timestamp, 0))
-		if stmts.upsertDaily != nil {
-			if _, err := stmts.upsertDaily.Exec(day); err != nil {
-				return err
-			}
+		// 不在这里直接 upsert 聚合，避免高并发下反复争抢同一天的聚合行。
+		// 改为“内存累加”，在事务提交前的收敛阶段一次性落库，并用 advisory lock 按天串行化。
+		if sessionAggDaily != nil {
+			sessionAggDaily[day]++
 		}
-		if stmts.upsertEntryDaily != nil {
-			if _, err := stmts.upsertEntryDaily.Exec(day, urlID); err != nil {
-				return err
+		if sessionAggEntry != nil {
+			if sessionAggEntry[day] == nil {
+				sessionAggEntry[day] = make(map[int64]int64)
 			}
+			sessionAggEntry[day][urlID]++
 		}
 		state = sessionState{sessionID: sessionID, lastTs: timestamp}
 	} else {
-		if _, err := stmts.updateSession.Exec(timestamp, urlID, state.sessionID); err != nil {
-			return err
+		// 不在循环里直接 UPDATE sessions：避免后续维表 INSERT/锁等待期间提前持有 session 行锁。
+		// 这里改为按 session_id 累加更新：end_ts 取最后一次的 timestamp，exit_url_id 取最后一次 url_id，page_count 增量累加。
+		if sessionUpdates != nil {
+			upd := sessionUpdates[state.sessionID]
+			if upd == nil {
+				upd = &pendingSessionUpdate{}
+				sessionUpdates[state.sessionID] = upd
+			}
+			upd.endTs = timestamp
+			upd.exitURLID = urlID
+			upd.pageCountDelta++
 		}
 		state.lastTs = timestamp
 	}
 
-	if _, err := stmts.upsertState.Exec(ipID, uaID, state.sessionID, state.lastTs); err != nil {
-		return err
+	// session_state 同理：收敛到事务末尾一次性 upsert，降低写放大与锁竞争。
+	if sessionStateUpserts != nil {
+		sessionStateUpserts[key] = pendingSessionStateUpsert{
+			ipID:      ipID,
+			uaID:      uaID,
+			sessionID: state.sessionID,
+			lastTs:    state.lastTs,
+		}
 	}
 	cache[key] = state
 	return nil


### PR DESCRIPTION
各部分改动内容概述（按模块）

1. Agent（cmd/nginxpulse-agent/main.go）
新增配置项与行为：
requestTimeout：推送 HTTP 超时
maxPendingLines：pending 积压上限（达到后背压暂停读取）
maxLineBytes：单行最大字节数，超长行跳过并告警（防 OOM）
retryBackoffMin/max：指数退避
exitOnMaxBackoff：达到最大退避后仍失败则退出进程（便于 k8s 重启）
新增诊断日志：
启动配置摘要、读文件统计（行数/字节/offset）、推送失败/退避、周期性内存统计（heap_alloc/heap_sys 等）
内存/heap_sys 优化：
推送成功后 不再复用 pending 的 backing array，而是直接换新 slice（降低旧字符串引用残留导致的 heap_sys 持续走高风险）
健壮性：
applyEnvOverrides 支持更多环境变量覆盖（例如 NGINXPULSE_AGENT_MAX_LINE_BYTES、NGINXPULSE_AGENT_EXIT_ON_MAX_BACKOFF）
2. Server 启动失败时退出容器（cmd/nginxpulse/main.go）
在 app.Run() 失败时，除了 os.Exit(1)，还会在 PID 1 为 nginx 的情况下向其发送 SIGTERM，避免 direct 模式下“后端失败但 nginx 仍在前台导致容器不退出”的情况。
3. IP 归属地/会话回填死锁优化（internal/enrich/ip_geo.go、internal/store/repository.go）
从 git diff 片段能看到主要集中在 repository 的会话/聚合写入路径：
新增 pg advisory lock（按 (ip_id, ua_id)、按天聚合 key）以减少并发写同一会话/同一天聚合导致的死锁/锁等待
把循环内频繁 UPDATE/UPSERT 改为“内存累加 + 事务末尾收敛落库”：
会话表 page_count 从 +1 改为 +?（增量累加）
daily/session-entry 聚合从固定 +1 改为按增量 excluded.count/sessions
聚合落库前对 day、entry_id 排序，降低锁顺序随机性
新增/调整 SQL statement 与结构：
新增 lockSessionKey / lockAggSessionDaily
引入 pendingSessionUpdate / pendingSessionStateUpsert 等收敛结构
4. Docker/配置示例
新增 Dockerfile.agent：改为多阶段构建（镜像内编译 agent，runtime 用 alpine，镜像体积显著变小）。
新增 agent 配置示例：configs/nginxpulse_agent.example.json（带注释示例文件）。
5. 修改归属地含"阿里"引发的Bug