### PR TITLE
修复 nginx 自定义 logFormat 中空 upstream_response_time 解析失败

### DIFF
--- a/internal/ingest/log_parser.go
+++ b/internal/ingest/log_parser.go
@@ -52,7 +52,7 @@ const (
 )
 
 var (
-	ipAliases            = []string{"ip", "remote_addr", "client_ip", "http_x_forwarded_for"}
+	ipAliases            = []string{"ip", "remote_addr", "real_client_ip", "client_ip", "http_x_forwarded_for"}
 	timeAliases          = []string{"time", "time_local", "time_iso8601"}
 	methodAliases        = []string{"method", "request_method"}
 	urlAliases           = []string{"url", "request_uri", "uri", "path"}

--- a/internal/ingest/log_parser_parse_factory.go
+++ b/internal/ingest/log_parser_parse_factory.go
@@ -234,6 +234,7 @@ func tokenRegexForVar(name string, used map[string]bool, quoted bool) string {
 	requiredTokenPattern := `\S+`
 	requiredQuotedPattern := `[^"]+`
 	if quoted {
+		commaListPattern = `(?:[^,\s]+(?:,\s*[^,\s]+)*)?`
 		optionalTokenPattern = optionalQuotedPattern
 		requiredTokenPattern = requiredQuotedPattern
 	}
@@ -241,6 +242,8 @@ func tokenRegexForVar(name string, used map[string]bool, quoted bool) string {
 	switch name {
 	case "remote_addr":
 		return addGroup("ip", requiredTokenPattern)
+	case "real_client_ip":
+		return addGroup("real_client_ip", requiredTokenPattern)
 	case "http_x_forwarded_for":
 		return addGroup("http_x_forwarded_for", commaListPattern)
 	case "remote_user":

--- a/internal/ingest/log_parser_trace_test.go
+++ b/internal/ingest/log_parser_trace_test.go
@@ -109,6 +109,66 @@ func TestDefaultNginxParserParsesExtendedTraceSuffix(t *testing.T) {
 	}
 }
 
+func TestNginxJSONLogFormatParsesEmptyUpstreamResponseTime(t *testing.T) {
+	parser, err := newLogLineParser(config.WebsiteConfig{
+		LogType:   "nginx",
+		LogFormat: nginxJSONTraceLogFormat(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("newLogLineParser(nginx json logFormat) error: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	line := `{"@timestamp":"` + now.Format(time.RFC3339) + `","host":"example.com","server_name":"example.com","scheme":"https","remote_addr":"203.0.113.10","request_method":"GET","request":"GET /index.html HTTP/1.1","status":200,"request_length":128,"body_bytes_sent":512,"request_time":0.012,"upstream_response_time":"","http_referer":"","http_user_agent":"curl/8.0.1","http_x_forwarded_for":""}`
+
+	p := &LogParser{retentionDays: 30}
+	record, err := p.parseRegexLogLine(parser, line)
+	if err != nil {
+		t.Fatalf("parseRegexLogLine error: %v", err)
+	}
+	if record.IP != "203.0.113.10" {
+		t.Fatalf("unexpected ip: %q", record.IP)
+	}
+	if record.RequestTimeMs != 12 {
+		t.Fatalf("unexpected request_time_ms: %d", record.RequestTimeMs)
+	}
+	if record.UpstreamTimeMs != 0 {
+		t.Fatalf("unexpected upstream_response_time_ms: %d", record.UpstreamTimeMs)
+	}
+	if record.Host != "example.com" {
+		t.Fatalf("unexpected host: %q", record.Host)
+	}
+}
+
+func TestNginxJSONLogFormatParsesQuotedUpstreamResponseTime(t *testing.T) {
+	parser, err := newLogLineParser(config.WebsiteConfig{
+		LogType:   "nginx",
+		LogFormat: nginxJSONTraceLogFormat(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("newLogLineParser(nginx json logFormat) error: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	line := `{"@timestamp":"` + now.Format(time.RFC3339) + `","host":"example.com","server_name":"example.com","scheme":"https","remote_addr":"203.0.113.10","request_method":"GET","request":"GET /api HTTP/1.1","status":200,"request_length":256,"body_bytes_sent":1024,"request_time":0.245,"upstream_response_time":"0.133","http_referer":"https://example.com/","http_user_agent":"curl/8.0.1","http_x_forwarded_for":"198.51.100.1"}`
+
+	p := &LogParser{retentionDays: 30}
+	record, err := p.parseRegexLogLine(parser, line)
+	if err != nil {
+		t.Fatalf("parseRegexLogLine error: %v", err)
+	}
+	if record.RequestTimeMs != 245 {
+		t.Fatalf("unexpected request_time_ms: %d", record.RequestTimeMs)
+	}
+	if record.UpstreamTimeMs != 133 {
+		t.Fatalf("unexpected upstream_response_time_ms: %d", record.UpstreamTimeMs)
+	}
+}
+
+func nginxJSONTraceLogFormat() string {
+	return `{"@timestamp":"$time_iso8601","host":"$host","server_name":"$server_name","scheme":"$scheme","remote_addr":"$real_client_ip","request_method":"$request_method","request":"$request","status":$status,"request_length":$request_length,"body_bytes_sent":$body_bytes_sent,"request_time":$request_time,"upstream_response_time":"$upstream_response_time","http_referer":"$http_referer","http_user_agent":"$http_user_agent","http_x_forwarded_for":"$http_x_forwarded_for"}`
+}
+
 func mustCompileRegex(t *testing.T, pattern string) *regexp.Regexp {
 	t.Helper()
 	regex, err := regexp.Compile(pattern)

--- a/webapp/src/pages/SetupPage.vue
+++ b/webapp/src/pages/SetupPage.vue
@@ -1022,7 +1022,7 @@ function createWebsiteDraft(prefillLogPath = ''): WebsiteDraft {
   };
 }
 
-const ipAliases = ['ip', 'remote_addr', 'client_ip', 'http_x_forwarded_for'];
+const ipAliases = ['ip', 'remote_addr', 'real_client_ip', 'client_ip', 'http_x_forwarded_for'];
 const timeAliases = ['time', 'time_local', 'time_iso8601'];
 const statusAliases = ['status'];
 const urlAliases = ['url', 'request_uri', 'uri', 'path'];
@@ -1321,10 +1321,11 @@ function tokenRegexForVar(name: string, used: Set<string>, quoted: boolean) {
     return `(?<${group}>${pattern})`;
   };
 
-  const commaListPattern = '[^,\\s]+(?:,\\s*[^,\\s]+)*';
+  let commaListPattern = '[^,\\s]+(?:,\\s*[^,\\s]+)*';
   let optionalTokenPattern = '\\S*';
   let requiredTokenPattern = '\\S+';
   if (quoted) {
+    commaListPattern = '(?:[^,\\s]+(?:,\\s*[^,\\s]+)*)?';
     optionalTokenPattern = '[^"]*';
     requiredTokenPattern = '[^"]+';
   }
@@ -1332,6 +1333,8 @@ function tokenRegexForVar(name: string, used: Set<string>, quoted: boolean) {
   switch (name) {
     case 'remote_addr':
       return addGroup('ip', requiredTokenPattern);
+    case 'real_client_ip':
+      return addGroup('real_client_ip', requiredTokenPattern);
     case 'http_x_forwarded_for':
       return addGroup('http_x_forwarded_for', commaListPattern);
     case 'remote_user':


### PR DESCRIPTION
## 概述

修复 nginx 自定义 `logFormat` 在 `$upstream_response_time` 展开为空字符串时解析失败的问题。

静态站点没有上游服务时，nginx 可能输出：

```json
"upstream_response_time":""
```

此前 `logFormat` 生成正则时，会把 `upstream_response_time` 当作非空逗号列表字段处理，导致整行日志匹配失败并报“日志格式不匹配”。

## 变更内容

- 允许自定义 `logFormat` 中被双引号包裹的逗号列表字段匹配空字符串。
- 未加引号的逗号列表字段保持原有非空匹配规则，避免影响普通空格分隔 nginx 日志。
- 支持 `$real_client_ip` 作为 IP 字段别名。
- 同步调整前端日志样例校验逻辑，保持前后端解析行为一致。
- 新增 JSON 风格 nginx `logFormat` 回归测试，覆盖：
  - 空 `"upstream_response_time":""`
  - 非空 `"upstream_response_time":"0.133"`
  - 空 quoted `"http_x_forwarded_for":""`

## 验证

已通过：

```bash
GOCACHE=/tmp/nginxpulse-go-build-cache go test ./internal/ingest
GOCACHE=/tmp/nginxpulse-go-build-cache go test ./...
git diff --check
```

未运行：

```bash
pnpm --dir webapp build
```

原因：本地缺少 `webapp/node_modules`，导致 `vite` 不可用。